### PR TITLE
Make project compatible with Ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source "https://rubygems.org"
 gem 'stytch', '~> 2.0.0'
 gem 'dotenv', '~> 2.7.6'
 gem 'sinatra', '~> 2.1.0'
-gem 'activesupport', '~>6.1.1'
+gem 'activesupport', '~> 6.1.1'
+gem 'thin', '~> 1.8.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,9 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     concurrent-ruby (1.1.8)
+    daemons (1.4.0)
     dotenv (2.7.6)
+    eventmachine (1.2.7)
     faraday (1.4.1)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
@@ -38,6 +40,10 @@ GEM
     stytch (2.0.0)
       faraday (>= 0.17.0, < 2.0)
       faraday_middleware (>= 0.14.0, < 2.0)
+    thin (1.8.1)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -51,6 +57,7 @@ DEPENDENCIES
   dotenv (~> 2.7.6)
   sinatra (~> 2.1.0)
   stytch (~> 2.0.0)
+  thin (~> 1.8.1)
 
 BUNDLED WITH
-   2.1.4
+   2.2.22


### PR DESCRIPTION
Ruby 2 and below have webrick in the standard library, Ruby 3 does not so you need to explicitly add a webserver - I added Thin.